### PR TITLE
Add `engines` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "tsd": "^0.18.0",
     "typescript": "^4.4.3"
   },
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/davidmarkclements/brittle.git"


### PR DESCRIPTION
To enable programmatic discovery of supported engines through a variety of tools

Maybe replace `>=16.0.0` with `^16.0.0` to be explicit that you don't currently support anything newer than `16`, but I think that would be a bit too strict for programmatic uses