### PR TITLE
documentation: many `teardown`s in one test

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -406,11 +406,9 @@ import test from 'brittle'
 test('some test', async ({ ok, teardown }) => {
  teardown(doSomeCleanUp)
  const assert = test('some sub test')
- setTime(() => {
-   const resource = createSomeResourceThatNeedsCleaningUpLaterOn()
-   teardown(async () => { await resource.cleanup() })
-   assert.is(resource.methodThatReturnsABoolean(), true)
- }, Math.random() * 1000)
+ const resource = createSomeResourceThatNeedsCleaningUpLaterOn()
+ teardown(async () => { await resource.cleanup() })
+ assert.is(resource.methodThatReturnsABoolean(), true)
  await assert
  ok('again, cool')
 })

--- a/readme.md
+++ b/readme.md
@@ -399,6 +399,23 @@ test('some test', async ({ ok, teardown }) => {
 })
 ```
 
+You can call `teardown` multiple times in a test and every function passed will be called after a test ends
+
+```js
+import test from 'brittle'
+test('some test', async ({ ok, teardown }) => {
+ teardown(doSomeCleanUp)
+ const assert = test('some sub test')
+ setTime(() => {
+   const resource = createSomeResourceThatNeedsCleaningUpLaterOn()
+   teardown(async () => { await resource.cleanup() })
+   assert.is(resource.methodThatReturnsABoolean(), true)
+ }, Math.random() * 1000)
+ await assert
+ ok('again, cool')
+})
+```
+
 #### `timeout(ms)`
 
 Fail the test after a given timeout.  

--- a/readme.md
+++ b/readme.md
@@ -399,7 +399,7 @@ test('some test', async ({ ok, teardown }) => {
 })
 ```
 
-You can call `teardown` multiple times in a test and every function passed will be called after a test ends
+If `teardown` is called multiple times in a test, every function passed will be called after the test ends
 
 ```js
 import test from 'brittle'


### PR DESCRIPTION
The documents `teardown`'s ability to accept multiple cleanup functions over the lifetime of a test.