### PR TITLE
Add Bare support for structured assertion errors output

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,9 +1,9 @@
 const { AssertionError } = require('assert')
 const fs = require('fs')
 const url = require('url')
-const process = require('process')
+const os = require('os')
 const StackParser = require('error-stack-parser')
-const { INDENT } = require('./constants')
+const { INDENT, IS_BARE } = require('./constants')
 
 const parseStack = StackParser.parse.bind(StackParser)
 
@@ -15,9 +15,11 @@ exports.explain = explain
 function explain (ok, message, assert, stackStartFunction, actual, expected, top, extra) {
   if (ok) return null
 
-  const cwd = process.cwd()
+  const cwd = IS_BARE ? os.cwd() : process.cwd()
+
   const err = new AssertionError({ stackStartFunction, message, operator: assert, actual, expected })
   stackScrub(err)
+
   if (top) {
     const line = top.getLineNumber()
     const column = top.getColumnNumber()

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "bare-assert": "^1.0.2",
     "bare-cov": "^1.1.0",
     "bare-fs": "^4.1.6",
+    "bare-os": "^3.6.1",
     "bare-path": "^3.0.0",
-    "bare-process": "^4.2.1",
     "bare-subprocess": "^5.0.0",
     "bare-url": "^2.1.6",
     "error-stack-parser": "^2.1.4",
@@ -52,11 +52,11 @@
     "fs": {
       "bare": "bare-fs"
     },
+    "os": {
+      "bare": "bare-os"
+    },
     "path": {
       "bare": "bare-path"
-    },
-    "process": {
-      "bare": "bare-process"
     },
     "url": {
       "bare": "bare-url"


### PR DESCRIPTION
sample:
```js
test((t) => t.alike({ key: 'value' }, { key: 'valu' }))
```

before:
```
# test
    not ok 1 - should deep equal
      ---
      source: 
      stack: |
        Object.explain (file:///Users/y/Documents/holepunch/brittle/lib/errors.js:19:15)
        explain (file:///Users/y/Documents/holepunch/brittle/index.js:840:34)
        Test._alike (file:///Users/y/Documents/holepunch/brittle/index.js:448:25)
        file:///Users/y/Documents/holepunch/brittle/_test.js:3:15
        Test._run (file:///Users/y/Documents/holepunch/brittle/index.js:597:13)
      ...
not ok 1 -  # time = 2ms

1..1
# tests = 0/1 pass
# asserts = 0/1 pass
# time = 2ms

# not ok
```

now:
```
# test
    not ok 1 - should deep equal
      ---
      actual: 
        key: value
      expected: 
        key: valu
      operator: alike
      source: |
        
        test((t) => t.alike({ key: 'value' }, { key: 'valu' }))
        --------------^
      stack: |
        Object.explain (./lib/errors.js:19:15)
        explain (./index.js:840:34)
        Test._alike (./index.js:448:25)
        ./_test.js:3:15
        Test._run (./index.js:597:13)
      ...
not ok 1 -  # time = 7ms
```
