### PR TITLE
Fix snapshot on Windows by switching to fileURLToPath

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -1,4 +1,5 @@
 const b4a = require('b4a')
+const { fileURLToPath } = require('url')
 
 exports.createTypedArray = function (TypedArray, src) {
   const b = b4a.from(src, 'base64')
@@ -62,7 +63,7 @@ function toString (s) {
 }
 
 function split (filename) {
-  if (filename.startsWith('file://')) filename = filename.slice(7)
+  if (filename.startsWith('file://')) filename = fileURLToPath(filename)
 
   const a = filename.lastIndexOf('/')
   const b = filename.lastIndexOf('\\')


### PR DESCRIPTION
The error occurs when the path of the file doing the snapshot is `file:///C:/Users/blabla`. With the existing implementation of just trimming the schema (`file://`, the path becomes `/C:/Users/blabla` with a / at the beginning. Using fileURLToPath makes this convert correctly correctly.