### PR TITLE
Print `-0` in explanation / YAML output

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -124,7 +124,7 @@ function toYAML (o, maxDepth = 5, indent = '', prev = null) {
   }
 
   // Print 0 & -0 correctly
-  if (o === 0) return o.toLocaleString('en') + '\n'
+  if (Object.is(o, -0)) return '-0\n'
 
   return '' + o + '\n'
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -123,5 +123,8 @@ function toYAML (o, maxDepth = 5, indent = '', prev = null) {
     return (p ? s.trimRight() : s.trim()) + '\n'
   }
 
+  // Print 0 & -0 correctly
+  if (o === 0) return o.toLocaleString('en') + '\n'
+
   return '' + o + '\n'
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -123,7 +123,7 @@ function toYAML (o, maxDepth = 5, indent = '', prev = null) {
     return (p ? s.trimRight() : s.trim()) + '\n'
   }
 
-  // Print 0 & -0 correctly
+  // Print -0 correctly
   if (Object.is(o, -0)) return '-0\n'
 
   return '' + o + '\n'

--- a/test/assertions.mjs
+++ b/test/assertions.mjs
@@ -106,6 +106,37 @@ await tester('passing (custom messages)',
   { exitCode: 0, stderr: '' }
 )
 
+await tester('stringify - prints negative zero',
+  async function (t) {
+    t.alike({ a: 0 }, { a: -0 }, 'check negative zero')
+  },
+  `
+  TAP version 13
+
+  # stringify - prints negative zero
+      not ok 1 - check negative zero
+        ---
+        actual: 
+          a: 0
+        expected: 
+          a: -0
+        operator: alike
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - prints negative zero # time = 3.140034ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 5.976933ms
+
+  # ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
 await tester('failing (default messages)',
   async function (t) {
     t.fail()


### PR DESCRIPTION
`(-0).toString()` and its string coercion returns `0` not `-0`. So when `same-object`'s `Object.is(0, -0)` fails, the explanation output can show identical results.

`o === 0` matches against both positive & negative zero. To print `-0` when it is negative `.toLocaleString()` is used. The locale is set to `en` to recreate the default algorithm for [`Number::toString()`](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-numeric-types-number-tostring) even in other locales (i.e. `ar-EG` which returns `-٠`).