### PR TITLE
Add watch functionality

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -20,6 +20,7 @@ const cmd = command('brittle',
   flag('--timeout, -t <timeout>', 'Set the test timeout in milliseconds (default: 30000)'),
   flag('--runner, -r <runner>', 'Generates an out file that contains all target tests'),
   flag('--mine, -m <miners>', 'Keep running the tests in <miners> processes until they fail.'),
+  flag('--watch, -w', 'Watch test files for changes and re-run on change'),
   flag('--unstealth, -u', 'Print out assertions even if stealth is used'),
   rest('<files>')
 ).parse(args)
@@ -52,7 +53,7 @@ if (files.length === 0) {
   process.exit(1)
 }
 
-const { solo, bail, timeout, coverage, covDir, mine, trace, unstealth } = argv
+const { solo, bail, timeout, coverage, covDir, mine, watch, trace, unstealth } = argv
 
 process.title = 'brittle'
 
@@ -113,6 +114,7 @@ if (argv.runner) {
 if (coverage && process.env.BRITTLE_COVERAGE !== 'false') require('bare-cov')({ dir: covDir })
 
 if (mine) startMining().catch()
+else if (watch) startWatching()
 else start().catch(onerror)
 
 function onerror (err) {
@@ -134,6 +136,86 @@ async function start () {
   }
 
   brittle.resume()
+}
+
+function startWatching () {
+  const fs = require('fs')
+
+  const args = [__filename]
+    .concat(solo ? ['--solo'] : [])
+    .concat(bail ? ['--bail'] : [])
+    .concat(unstealth ? ['--unstealth'] : [])
+    .concat(trace ? ['--trace'] : [])
+    .concat(timeout ? ['--timeout', timeout + ''] : [])
+    .concat(files)
+
+  let current = null
+  let debounceTimer = null
+  let pendingRestart = false
+
+  const resolvedFiles = files.map(f => path.resolve(f))
+  const lastMtimes = new Map(resolvedFiles.map(f => [f, mtime(f)]))
+  const watchers = resolvedFiles.map(f => fs.watch(f, function () { onchange(f) }))
+
+  process.once('SIGINT', bail)
+  process.once('SIGTERM', bail)
+
+  console.log('Watching for changes...\n')
+  run()
+
+  function mtime (f) {
+    try { return fs.statSync(f).mtimeMs } catch { return 0 }
+  }
+
+  function snapshotMtimes () {
+    for (const f of resolvedFiles) lastMtimes.set(f, mtime(f))
+  }
+
+  function onchange (f) {
+    if (mtime(f) === lastMtimes.get(f)) return
+    if (current) { current.restarting = true; return }
+    if (pendingRestart) return
+    pendingRestart = true
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(restart, 100)
+  }
+
+  function bail () {
+    for (const w of watchers) w.close()
+    if (current) current.kill()
+    process.exit(0)
+  }
+
+  function restart () {
+    if (current) {
+      current.restarting = true
+      current.kill()
+    } else {
+      console.log('\n--- File changed, re-running tests ---\n')
+      run()
+    }
+  }
+
+  function run () {
+    snapshotMtimes()
+    const p = spawn(process.execPath, args, { stdio: 'inherit' })
+    const proc = {
+      restarting: false,
+      kill: () => p.kill()
+    }
+    current = proc
+
+    p.on('exit', () => {
+      if (current === proc) current = null
+      pendingRestart = false
+      if (proc.restarting) {
+        console.log('\n--- File changed, re-running tests ---\n')
+        run()
+      } else {
+        console.log('\nWatching for changes...')
+      }
+    })
+  }
 }
 
 async function startMining () {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -9,7 +9,7 @@ const pkg = JSON.stringify(path.join(__dirname, '..', '..', 'index.js'))
 const EXIT_CODES_KV = { ok: 0, error: 1 }
 const EXIT_CODES_VK = { 0: 'ok', 1: 'error' }
 
-module.exports = { tester, spawner, standardizeTap }
+module.exports = { tester, spawner, watcher, standardizeTap }
 
 async function tester (name, fn, expectedOut, expectedMore, opts) {
   log(chalk.yellow.bold('Tester'), name)
@@ -187,6 +187,81 @@ function standardizeTap (stdout) {
     .map(n => n.trim())
     .filter(n => n)
     .join('\n')
+}
+
+async function watcher (name, fn) {
+  log(chalk.yellow.bold('Watcher'), name)
+
+  const root = path.join(__dirname, '../..')
+  const cmd = path.join(root, 'cmd.js')
+  const relFile = 'tmp-watch-' + Math.random().toString(16).slice(2) + '.mjs'
+  const absFile = path.join(root, relFile)
+  const errors = new Errors()
+
+  function writeFixture (testName) {
+    fs.writeFileSync(absFile, 'import test from ' + pkg + '\ntest(' + JSON.stringify(testName) + ', function (t) { t.pass() })\n')
+  }
+
+  writeFixture(name)
+
+  let output = ''
+  const p = spawn(process.execPath, [cmd, '--watch', relFile], { stdio: 'pipe', cwd: root })
+  p.stdout.setEncoding('utf-8')
+  p.stdout.on('data', function (chunk) { output += chunk })
+
+  const api = {
+    get output () { return output },
+    resetOutput () { output = '' },
+    write (testName) { writeFixture(testName) },
+    waitForDone () { return waitFor(function () { return output.includes('\nWatching for changes') }) },
+    ok (value, message) {
+      if (!value) errors.add('ASSERTION', message || 'expected truthy value', value, true)
+    },
+    is (actual, expected, message) {
+      if (actual !== expected) errors.add('ASSERTION', message || 'expected equal', actual, expected)
+    }
+  }
+
+  try {
+    await fn(api)
+  } catch (err) {
+    errors.add('WATCHER_ERROR', err)
+  } finally {
+    p.kill()
+    await new Promise(function (resolve) { p.on('exit', resolve) })
+    try { fs.unlinkSync(absFile) } catch {}
+  }
+
+  if (errors.list.length) {
+    process.exitCode = 1
+
+    for (const err of errors.list) {
+      console.error(chalk.red.bold('Error:'), err.error.message)
+
+      if (Object.hasOwn(err, 'actual') || Object.hasOwn(err, 'expected')) {
+        console.error(chalk.red('[actual]'))
+        console.error(err.actual)
+        console.error(chalk.red('[expected]'))
+        console.error(err.expected)
+      }
+    }
+  }
+}
+
+function waitFor (fn, timeout) {
+  timeout = timeout || 5000
+  return new Promise(function (resolve, reject) {
+    const deadline = Date.now() + timeout
+    const tick = setInterval(function () {
+      if (fn()) {
+        clearInterval(tick)
+        resolve()
+      } else if (Date.now() > deadline) {
+        clearInterval(tick)
+        reject(new Error('timed out waiting for condition'))
+      }
+    }, 50)
+  })
 }
 
 function log (...str) {

--- a/test/watch.mjs
+++ b/test/watch.mjs
@@ -1,0 +1,38 @@
+import { watcher } from './helpers/index.js'
+
+await watcher('watch - runs on start', async function (w) {
+  await w.waitForDone()
+  w.ok(w.output.includes('# ok'), 'initial run passed')
+})
+
+await watcher('watch - re-runs exactly once on file change', async function (w) {
+  await w.waitForDone()
+  w.resetOutput()
+
+  w.write('v2')
+
+  await w.waitForDone()
+
+  w.is((w.output.match(/--- File changed/g) || []).length, 1, 'exactly one re-run triggered')
+  w.ok(w.output.includes('# ok'), 're-run passed')
+})
+
+await watcher('watch - re-runs all files when one changes', async function (w) {
+  await w.waitForDone()
+  w.resetOutput()
+
+  w.write('v2')
+
+  await w.waitForDone()
+
+  w.ok(w.output.includes('# ok'), 're-ran all tests on change')
+})
+
+await watcher('watch - no re-run without file change', async function (w) {
+  await w.waitForDone()
+  w.resetOutput()
+
+  await new Promise(function (resolve) { setTimeout(resolve, 500) })
+
+  w.is(w.output, '', 'no output without a file change')
+})


### PR DESCRIPTION
CLI supports `--watch` or `-w` to watch files and re-run test after the file is modified.