### PR TITLE
fix(stringify): display complex types meaningfully in assertion output

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,6 +2,8 @@ const { AssertionError } = require('assert')
 const fs = require('fs')
 const url = require('url')
 const os = require('os')
+const util = require('util')
+
 const StackParser = require('error-stack-parser')
 const { INDENT, IS_BARE } = require('./constants')
 
@@ -141,6 +143,8 @@ function toYAML(o, maxDepth = 5, indent = '', prev = null) {
     )
   }
 
+  if (typeof o === 'symbol') return o.toString() + '\n'
+
   if (Array.isArray(o) || o instanceof Set) {
     let s = prev ? '\n' : ''
     for (const i of o) {
@@ -150,6 +154,14 @@ function toYAML(o, maxDepth = 5, indent = '', prev = null) {
   }
 
   if (o && typeof o === 'object') {
+    if (o instanceof RegExp) return o.toString() + '\n'
+    if (o instanceof Date) return o.toISOString() + '\n'
+    if (o instanceof Error) return o.toString() + '\n'
+    if (o instanceof Map) return 'Map(' + o.size + ') {}\n'
+    if (o instanceof WeakMap) return 'WeakMap {}\n'
+    if (o instanceof WeakSet) return 'WeakSet {}\n'
+    if (o instanceof Promise) return inspectPromise(o) + '\n'
+
     const p = prev && prev !== 'array'
     let s = p ? '\n' : ''
     for (const k of Object.keys(o)) {
@@ -163,4 +175,18 @@ function toYAML(o, maxDepth = 5, indent = '', prev = null) {
   if (Object.is(o, -0)) return '-0\n'
 
   return '' + o + '\n'
+}
+
+function inspectPromise(p) {
+  try {
+    const s = util.inspect(p, { colors: false })
+    if (!s.includes('\n')) return s
+    // Reduce down to just the error message
+    const lines = s.split('\n').map((l) => l.trim())
+    const header = lines[0] // "Promise {"
+    const content = lines.slice(1).filter((l) => l && l !== '}' && !l.startsWith('at '))
+    return header + ' ' + content.join(' ') + ' }'
+  } catch {
+    return 'Promise {}'
+  }
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
     "events": {
       "bare": "bare-events",
       "default": "events"
+    },
+    "util": {
+      "bare": "bare-utils",
+      "default": "util"
     }
   },
   "repository": {

--- a/test/multitick-execution-exception.mjs
+++ b/test/multitick-execution-exception.mjs
@@ -46,7 +46,7 @@ await tester(
       ok 1 - first
       not ok 2 - should resolve
         ---
-        actual: 
+        actual: Error: test
         expected: null
         operator: execution
         stack: async _fn ([eval]:5:5)
@@ -165,7 +165,7 @@ await tester(
       ok 2 - second
       not ok 3 - should resolve
         ---
-        actual: 
+        actual: Error: test
         expected: null
         operator: execution
         ...

--- a/test/stringify-complex-types.mjs
+++ b/test/stringify-complex-types.mjs
@@ -1,0 +1,243 @@
+import { tester } from './helpers/index.js'
+
+await tester(
+  'stringify - resolved Promise shows value in t.is failure',
+  function (t) {
+    t.is(Promise.resolve(42), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - resolved Promise shows value in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Promise { 42 }
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - resolved Promise shows value in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - pending Promise shows pending in t.is failure',
+  function (t) {
+    t.is(new Promise(() => {}), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - pending Promise shows pending in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Promise { <pending> }
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - pending Promise shows pending in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - rejected Promise shows error in t.is failure',
+  function (t) {
+    const p = Promise.reject(new Error('oops'))
+    p.catch(() => {}) // suppress unhandledRejection
+    t.is(p, 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - rejected Promise shows error in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Promise { <rejected> Error: oops }
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - rejected Promise shows error in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - Symbol shows type label in t.is failure',
+  function (t) {
+    t.is(Symbol('test'), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - Symbol shows type label in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Symbol(test)
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - Symbol shows type label in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - RegExp shows pattern in t.is failure',
+  function (t) {
+    t.is(/foo/gi, 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - RegExp shows pattern in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: /foo/gi
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - RegExp shows pattern in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - Date shows ISO string in t.is failure',
+  function (t) {
+    t.is(new Date('2024-01-01T00:00:00.000Z'), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - Date shows ISO string in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: 2024-01-01T00:00:00.000Z
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - Date shows ISO string in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - Error shows message in t.is failure',
+  function (t) {
+    t.is(new Error('oops'), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - Error shows message in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Error: oops
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - Error shows message in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)
+
+await tester(
+  'stringify - Map shows type label in t.is failure',
+  function (t) {
+    t.is(new Map([['a', 1]]), 'expected')
+  },
+  `
+  TAP version 13
+
+  # stringify - Map shows type label in t.is failure
+      not ok 1 - should be equal
+        ---
+        actual: Map(1) {}
+        expected: expected
+        operator: is
+        stack: |
+          _fn ([eval]:4:7)
+          process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+        ...
+  not ok 1 - stringify - Map shows type label in t.is failure # time = 0ms
+
+  1..1
+  # tests = 0/1 pass
+  # asserts = 0/1 pass
+  # time = 0ms
+
+  # not ok
+  `,
+  { exitCode: 1, stderr: '' }
+)


### PR DESCRIPTION
## Summary

- `toYAML` in `lib/errors.js` rendered Promises, Errors, RegExps, Dates, Maps, WeakMaps, WeakSets, and Symbols as **blank** in assertion failure output (Symbol also crashed with `TypeError`), because `Object.keys()` returns no enumerable own properties for these built-in types
- Adds special-case handling for each: Symbol/RegExp/Error via `.toString()`, Date via `.toISOString()`, Map/WeakMap/WeakSet as type labels, Promise via `util.inspect` (mapped to `bare-inspect` on Bare via the import map)
- Adds `util` to the `package.json` import map so `require('util')` resolves to `bare-utils` on Bare
- The multi-line rejected Promise format differs between Node and Bare (`<rejected> Error: msg` on one line vs two) — handled by splitting, filtering out stack frames, and rejoining

## Test plan

- [x] New test file `test/stringify-complex-types.mjs` covers all 8 cases (resolved/pending/rejected Promise, Symbol, RegExp, Date, Error, Map) on both runtimes
- [x] Updated `test/multitick-execution-exception.mjs` to expect `Error: test` instead of blank for execution failures
- [x] `npm run test:node` passes
- [x] `npm run test:bare` passes (only pre-existing `threads.mjs` failure due to missing `bare-channel` in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)