### PR TITLE
feat(output): add a failures roll-up to the summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,24 @@ piping to a TAP consumer or a log file is unaffected.
 - the tallies are green when everything passed and bold red otherwise
 - timings, plan lines and `TAP version 13` are dimmed
 
+Every failed test is also listed in a roll-up before the final verdict, so a long run does
+not have to be scrolled to find what broke:
+
+```
+1..5
+# tests = 4/5 pass
+# asserts = 3/4 pass
+# time = 15ms
+
+# failures:
+#   - failing
+
+# not ok
+```
+
+The roll-up is emitted as TAP comments, so it is present with or without colors and is
+ignored by TAP consumers.
+
 Detection can be overridden, highest precedence first:
 
 - `configure({ color: true })` / `configure({ color: false })`

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ It must be executed before any tests.
 - `unstealth` (`false`) - show assertions even if `stealth` is used
 - `coverage` (`false`) - enable coverage reporting (string path of the output directory or `true` for default)
 - `jobs` (`1`) - number of test files to run concurrently (Bare-only)
+- `color` (auto-detected) - colorize the output. See [Colors](#colors)
 
 ```js
 import { configure } from 'brittle'
@@ -829,6 +830,7 @@ Flags:
   --timeout, -t <timeout>   Set the test timeout in milliseconds (default: 30000)
   --mine, -m <miners>       Keep running the tests in <miners> processes until they fail.
   --jobs, -j <jobs>         Run <jobs> test files concurrently [Bare-only] (default: 1)
+  --color                   Colorize the output, --no-color to disable (default: auto-detect)
   --unstealth, -u           Show assertions even if stealth is used
   --help|-h                 Show help
 ```
@@ -849,6 +851,33 @@ Force disable coverage with an environment variable:
 
 ```shell
 BRITTLE_COVERAGE=false brittle-node test.js
+```
+
+### Colors
+
+Output is colorized when it is written to a terminal and left as plain TAP otherwise, so
+piping to a TAP consumer or a log file is unaffected.
+
+- `ok` is green, bold for a test result and plain for an assertion
+- `not ok` is bold red, followed by the message in red
+- skipped and todo tests are yellow with a bold `# SKIP` / `# TODO` marker
+- failure explanations read like a diff: `actual` in red, `expected` in green, other keys
+  bold with gray values, the `^` source pointer bold red, and the stack dimmed
+- the tallies are green when everything passed and bold red otherwise
+- timings, plan lines and `TAP version 13` are dimmed
+
+Detection can be overridden, highest precedence first:
+
+- `configure({ color: true })` / `configure({ color: false })`
+- `--color` / `--no-color`
+- `NO_COLOR` set to a non-empty value disables colors
+- `FORCE_COLOR` enables colors, except when set to `0` or `false`
+- `TERM=dumb` disables colors
+
+```shell
+brittle-node --no-color test.js
+NO_COLOR=1 brittle-node test.js
+FORCE_COLOR=1 brittle-node test.js | less -R
 ```
 
 ### Coverage

--- a/cmd.js
+++ b/cmd.js
@@ -27,6 +27,7 @@ const cmd = command(
   flag('--mine, -m <miners>', 'Keep running the tests in <miners> processes until they fail.'),
   flag('--unstealth, -u', 'Print out assertions even if stealth is used'),
   flag('--jobs, -j <jobs>', 'Run <jobs> test files concurrently [Bare-only] (default: 1)'),
+  flag('--color', 'Colorize the output, --no-color to disable (default: auto-detect)'),
   rest('<files>')
 ).parse(args)
 if (!cmd) process.exit(0)
@@ -47,6 +48,8 @@ if (files.length === 0) {
 }
 
 const { solo, bail, timeout, coverage, covDir, mine, trace, unstealth, jobs } = argv
+
+const color = cmd.indices.flags.color === undefined ? undefined : argv.color
 
 if (argv.pick && argv.pick.length > 1) {
   console.error('Error: --pick can only be used once')
@@ -91,11 +94,12 @@ function onerror(err) {
 async function start() {
   const brittle = require('./')
 
-  if (bail || solo || unstealth || timeout || jobs || pick !== undefined) {
+  if (bail || solo || unstealth || timeout || jobs || pick !== undefined || color !== undefined) {
     brittle.configure({
       bail,
       solo,
       unstealth,
+      color,
       timeout: timeout ? Number(timeout) : undefined,
       jobs: jobs ? Number(jobs) : undefined,
       pick: pick !== undefined ? Number(pick) : undefined
@@ -124,6 +128,7 @@ async function startMining() {
     .concat(timeout ? ['--timeout', timeout + ''] : [])
     .concat(jobs ? ['--jobs', jobs] : [])
     .concat(pick !== undefined ? ['--pick', pick + ''] : [])
+    .concat(color === undefined ? [] : [color ? '--color' : '--no-color'])
     .concat(files)
 
   const running = new Set()

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class Runner {
     this.count = 0
     this.picked = null
     this.colors = createColors()
+    this._failures = []
 
     this.hooks = new Set()
 
@@ -107,6 +108,7 @@ class Runner {
         console.log(colors.dim('TAP version 13'))
       } else if (type === 'assert') {
         const [indent, oknotok, number, message] = args
+        if (oknotok !== 'ok' && indent === '') this._failures.push(describeTest(message))
         console.log(`${indent}${this._formatAssert(indent, oknotok, number, message)}`)
       } else if (type === 'comment') {
         const [indent, ...rest] = args
@@ -140,6 +142,13 @@ class Runner {
           )
         )
         console.log(colors.dim('# time = ' + this._timer() + 'ms'))
+
+        if (this._failures.length > 0) {
+          console.log()
+          console.log(colors.boldRed('# failures:'))
+          for (const name of this._failures) console.log(colors.red('#   - ' + name))
+        }
+
         console.log()
 
         const isOk = testsOk && assertionsOk
@@ -1192,6 +1201,13 @@ function styleOf(colors, key) {
   if (key === 'actual') return [colors.boldRed, colors.red]
   if (key === 'expected') return [colors.boldGreen, colors.green]
   return [colors.bold, colors.gray]
+}
+
+// '- name # time = 1ms' -> 'name'
+function describeTest(message) {
+  const name = message.replace(/^- /, '')
+  const marker = name.indexOf(' # ')
+  return marker === -1 ? name : name.slice(0, marker)
 }
 
 function prematureEnd(t, message) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const b4a = require('b4a')
 const { getSnapshot, createTypedArray } = require('./lib/snapshot')
 const { INDENT, RUNNER, IS_NODE, IS_BARE, DEFAULT_TIMEOUT } = require('./lib/constants')
 const AssertionError = require('./lib/assertion-error')
+const { createColors } = require('./lib/colors')
 const TracingPromise = require('./lib/tracing-promise')
 const Promise = TracingPromise.Untraced // never trace internal onces
 
@@ -50,6 +51,7 @@ class Runner {
     this.index = undefined
     this.count = 0
     this.picked = null
+    this.colors = createColors()
 
     this.hooks = new Set()
 
@@ -99,37 +101,121 @@ class Runner {
     }
 
     return (type, ...args) => {
+      const colors = this.colors
+
       if (type === 'start') {
-        console.log('TAP version 13')
+        console.log(colors.dim('TAP version 13'))
       } else if (type === 'assert') {
         const [indent, oknotok, number, message] = args
-        console.log(`${indent}${oknotok} ${number} ${message}`)
+        console.log(`${indent}${this._formatAssert(indent, oknotok, number, message)}`)
       } else if (type === 'comment') {
         const [indent, ...rest] = args
-        console.log(`${indent}#`, ...rest)
+        const style = indent === '' ? colors.bold : colors.dim
+        if (rest.every((part) => typeof part === 'string')) {
+          console.log(style(indent + (rest.length ? '# ' + rest.join(' ') : '#')))
+        } else {
+          console.log(style(`${indent}#`), ...rest)
+        }
+      } else if (type === 'explanation') {
+        console.log(this._formatExplanation(args.join(' ')))
       } else if (type === 'results') {
         const [tests, assertions] = args
 
-        if (this.bail && this.skipAll) console.log('Bail out!')
+        if (this.bail && this.skipAll) console.log(colors.boldRed('Bail out!'))
 
         this.padding()
 
-        console.log('1..' + tests.count)
-        console.log('# tests = ' + tests.pass + '/' + tests.count + ' pass')
-        console.log('# asserts = ' + assertions.pass + '/' + assertions.count + ' pass')
-        console.log('# time = ' + this._timer() + 'ms')
+        const testsOk = tests.count === tests.pass
+        const assertionsOk = assertions.count === assertions.pass
+
+        console.log(colors.dim('1..' + tests.count))
+        console.log(
+          (testsOk ? colors.green : colors.boldRed)(
+            '# tests = ' + tests.pass + '/' + tests.count + ' pass'
+          )
+        )
+        console.log(
+          (assertionsOk ? colors.green : colors.boldRed)(
+            '# asserts = ' + assertions.pass + '/' + assertions.count + ' pass'
+          )
+        )
+        console.log(colors.dim('# time = ' + this._timer() + 'ms'))
         console.log()
 
-        const isOk = tests.count === tests.pass && assertions.count === assertions.pass
-        console.log(`# ${isOk ? 'ok' : 'not ok'}`)
+        const isOk = testsOk && assertionsOk
+        console.log((isOk ? colors.boldGreen : colors.boldRed)(`# ${isOk ? 'ok' : 'not ok'}`))
       } else {
         console.log(...args)
       }
     }
   }
 
+  _formatAssert(indent, oknotok, number, message) {
+    const colors = this.colors
+    if (!colors.enabled) return `${oknotok} ${number} ${message}`
+
+    const top = indent === ''
+    const time = message.match(/ # time = .*$/)
+    const description = time ? message.slice(0, time.index) : message
+
+    if (oknotok !== 'ok') {
+      return `${colors.boldRed('not ok')}${colors.red(` ${number} ${description}`)}${
+        time ? colors.dim(time[0]) : ''
+      }`
+    }
+
+    if (/ # (?:SKIP|TODO)\b/.test(message)) {
+      const marker = message.match(/ # (?:SKIP|TODO)\b.*$/)
+      return `${colors.boldYellow('ok')}${colors.yellow(
+        ` ${number} ${message.slice(0, marker.index)}`
+      )}${colors.boldYellow(marker[0])}`
+    }
+
+    const ok = top ? colors.boldGreen('ok') : colors.green('ok')
+
+    return `${ok} ${number} ${description}${time ? colors.dim(time[0]) : ''}`
+  }
+
+  // the explanation is a YAML block. Style it like a diff: expected in green,
+  // actual in red, the source pointer highlighted, the stack pushed into the background
+  _formatExplanation(block) {
+    const colors = this.colors
+    if (!colors.enabled) return block
+
+    const top = INDENT.length + 2
+    let key = null
+
+    return block
+      .split('\n')
+      .map((line) => {
+        const trimmed = line.trim()
+        if (trimmed === '') return line
+
+        if (trimmed === '---' || trimmed === '...') {
+          key = null
+          return colors.dim(line)
+        }
+
+        const pair = /^(\s*)([\w$]+): ?(.*)$/.exec(line)
+
+        if (pair && pair[1].length === top) {
+          key = pair[2]
+          const [label, value] = styleOf(colors, key)
+          return label(`${pair[1]}${key}:`) + (pair[3] === '' ? '' : ' ' + value(pair[3]))
+        }
+
+        if (key === 'stack') return colors.dim(line)
+        if (key === 'source') {
+          return /^-*\^$/.test(trimmed) ? colors.boldRed(line) : colors.gray(line)
+        }
+
+        return styleOf(colors, key)[1](line)
+      })
+      .join('\n')
+  }
+
   applyConfig(config) {
-    const { timeout, bail, solo, unstealth, source, jobs, coverage, pick: index } = config
+    const { timeout, bail, solo, unstealth, source, jobs, coverage, color, pick: index } = config
     if (coverage && !this.coverage) {
       this.coverage = coverage
       require('bare-cov')({ dir: typeof coverage === 'string' ? coverage : undefined })
@@ -141,6 +227,7 @@ class Runner {
     if (source !== undefined) this.source = source
     if (jobs !== undefined) this.jobs = jobs
     if (index !== undefined) this.index = index
+    if (color !== undefined) this.colors = createColors(color)
   }
 
   resume() {
@@ -1099,6 +1186,12 @@ function isUncaught(err) {
 function getRunner() {
   if (!global[RUNNER]) global[RUNNER] = new Runner()
   return global[RUNNER]
+}
+
+function styleOf(colors, key) {
+  if (key === 'actual') return [colors.boldRed, colors.red]
+  if (key === 'expected') return [colors.boldGreen, colors.green]
+  return [colors.bold, colors.gray]
 }
 
 function prematureEnd(t, message) {

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,72 @@
+const ansi = require('bare-ansi-escapes')
+const process = require('process')
+
+const { modifierReset, modifierBold, modifierDim } = ansi
+
+const STYLES = {
+  green: ansi.colorGreen,
+  red: ansi.colorRed,
+  yellow: ansi.colorYellow,
+  gray: ansi.colorBrightBlack,
+  bold: modifierBold,
+  dim: modifierDim,
+  boldGreen: modifierBold + ansi.colorGreen,
+  boldRed: modifierBold + ansi.colorRed,
+  boldYellow: modifierBold + ansi.colorYellow
+}
+
+const NAMES = Object.keys(STYLES)
+
+function identity(string) {
+  return string
+}
+
+function env(name) {
+  try {
+    return process.env?.[name]
+  } /* c8 ignore next */ catch {
+    /* c8 ignore next */
+    return undefined
+  }
+}
+
+function isColorSupported() {
+  const noColor = env('NO_COLOR')
+  if (noColor) return false
+
+  const forceColor = env('FORCE_COLOR')
+  if (forceColor !== undefined && forceColor !== '') {
+    return forceColor !== '0' && forceColor !== 'false'
+  }
+
+  if (env('TERM') === 'dumb') return false
+
+  try {
+    return process.stdout?.isTTY === true
+  } /* c8 ignore next */ catch {
+    /* c8 ignore next */
+    return false
+  }
+}
+
+function paint(open) {
+  return function (string) {
+    string = string + ''
+    if (string === '') return string
+    // per line so that resets survive wrapping and indentation
+    return string
+      .split('\n')
+      .map((line) => (line === '' ? line : open + line + modifierReset))
+      .join('\n')
+  }
+}
+
+function createColors(enabled = isColorSupported()) {
+  const colors = { enabled: !!enabled }
+  for (const name of NAMES) {
+    colors[name] = enabled ? paint(STYLES[name]) : identity
+  }
+  return colors
+}
+
+module.exports = { createColors, isColorSupported }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "b4a": "^1.8.0",
+    "bare-ansi-escapes": "^2.2.3",
     "bare-assert": "^1.2.0",
     "bare-buffer": "^3.6.0",
     "bare-channel": "^5.2.3",

--- a/test/color.mjs
+++ b/test/color.mjs
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import { createColors, isColorSupported } from '../lib/colors.js'
+
+const GREEN = '\x1b[32m'
+const RED = '\x1b[31m'
+const YELLOW = '\x1b[33m'
+const GRAY = '\x1b[90m'
+const BOLD = '\x1b[1m'
+const DIM = '\x1b[2m'
+const RESET = '\x1b[0m'
+const BOLD_GREEN = BOLD + GREEN
+const BOLD_RED = BOLD + RED
+const BOLD_YELLOW = BOLD + YELLOW
+
+// createColors(false) leaves every string untouched
+
+{
+  const colors = createColors(false)
+  assert.strictEqual(colors.enabled, false)
+  const names = ['green', 'red', 'yellow', 'gray', 'bold', 'dim', 'boldGreen', 'boldRed']
+  for (const name of names) {
+    assert.strictEqual(colors[name]('ok 1 - passed'), 'ok 1 - passed')
+  }
+}
+
+// createColors(true) wraps in the matching SGR sequence
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.enabled, true)
+  assert.strictEqual(colors.green('ok'), GREEN + 'ok' + RESET)
+  assert.strictEqual(colors.red('not ok'), RED + 'not ok' + RESET)
+  assert.strictEqual(colors.yellow('SKIP'), YELLOW + 'SKIP' + RESET)
+  assert.strictEqual(colors.gray('---'), GRAY + '---' + RESET)
+  assert.strictEqual(colors.bold('# test'), BOLD + '# test' + RESET)
+  assert.strictEqual(colors.dim('# time = 0ms'), DIM + '# time = 0ms' + RESET)
+  assert.strictEqual(colors.boldGreen('# ok'), BOLD_GREEN + '# ok' + RESET)
+  assert.strictEqual(colors.boldRed('# not ok'), BOLD_RED + '# not ok' + RESET)
+  assert.strictEqual(colors.boldYellow('# SKIP'), BOLD_YELLOW + '# SKIP' + RESET)
+}
+
+// empty strings and blank lines are never wrapped, other lines are wrapped individually
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.green(''), '')
+  assert.strictEqual(
+    colors.gray('---\n\nactual: 1'),
+    GRAY + '---' + RESET + '\n\n' + GRAY + 'actual: 1' + RESET
+  )
+}
+
+// non-strings are coerced
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.green(1), GREEN + '1' + RESET)
+}
+
+// detection defaults to whatever the current stdout is
+
+{
+  assert.strictEqual(typeof isColorSupported(), 'boolean')
+  assert.strictEqual(createColors().enabled, isColorSupported())
+}

--- a/test/color.mjs
+++ b/test/color.mjs
@@ -1,5 +1,13 @@
 import assert from 'assert'
+import path from 'path'
+import process from 'process'
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'url'
+import { raw } from './helpers/index.js'
 import { createColors, isColorSupported } from '../lib/colors.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 const GREEN = '\x1b[32m'
 const RED = '\x1b[31m'
@@ -11,6 +19,10 @@ const RESET = '\x1b[0m'
 const BOLD_GREEN = BOLD + GREEN
 const BOLD_RED = BOLD + RED
 const BOLD_YELLOW = BOLD + YELLOW
+
+// a known-neutral environment, so that a NO_COLOR/FORCE_COLOR in the ambient
+// environment cannot flip the expectations below
+const NEUTRAL = { NO_COLOR: '', FORCE_COLOR: '', TERM: 'xterm-256color' }
 
 // createColors(false) leaves every string untouched
 
@@ -62,4 +74,262 @@ const BOLD_YELLOW = BOLD + YELLOW
 {
   assert.strictEqual(typeof isColorSupported(), 'boolean')
   assert.strictEqual(createColors().enabled, isColorSupported())
+}
+
+// env precedence, one child process per case. The environment is not mutated in
+// place because that is not portable across runtimes.
+
+{
+  const cases = [
+    { env: { FORCE_COLOR: '1' }, color: true, why: 'FORCE_COLOR enables' },
+    { env: { FORCE_COLOR: '1', NO_COLOR: '1' }, color: false, why: 'NO_COLOR beats FORCE_COLOR' },
+    { env: { FORCE_COLOR: '0' }, color: false, why: 'FORCE_COLOR=0 disables' },
+    { env: { FORCE_COLOR: 'false' }, color: false, why: 'FORCE_COLOR=false disables' },
+    { env: { TERM: 'dumb' }, color: false, why: 'TERM=dumb disables' },
+    { env: { FORCE_COLOR: '1', TERM: 'dumb' }, color: true, why: 'FORCE_COLOR beats TERM=dumb' },
+    { env: {}, color: false, why: 'a pipe is not colorized' }
+  ]
+
+  for (const { env, color, why } of cases) {
+    const { stdout, exitCode } = await raw(
+      function (test) {
+        test('detect', (t) => t.pass())
+      },
+      { env: { ...NEUTRAL, ...env } }
+    )
+
+    assert.strictEqual(exitCode, 0, why)
+    assert.strictEqual(stdout.includes('\x1b['), color, why)
+  }
+}
+
+// FORCE_COLOR colorizes passes, skips, todos, failures and the summary
+
+{
+  const { stdout } = await raw(
+    function (test) {
+      test('passing', (t) => {
+        t.plan(1)
+        t.pass('yes')
+      })
+      test('skipping', { skip: true }, (t) => t.pass())
+      test('todoing', { todo: true }, (t) => t.pass())
+      test('failing', (t) => {
+        t.plan(1)
+        t.comment('here we go')
+        t.fail('nope')
+      })
+    },
+    { env: { ...NEUTRAL, FORCE_COLOR: '1' } }
+  )
+
+  assert.ok(stdout.includes(DIM + 'TAP version 13' + RESET), 'TAP version line is dimmed')
+  assert.ok(stdout.includes(BOLD + '# passing' + RESET), 'test name comments are bold')
+  assert.ok(stdout.includes(DIM + '    # here we go' + RESET), 'nested comments are dimmed')
+
+  assert.ok(stdout.includes('    ' + GREEN + 'ok' + RESET + ' 1 - yes'), 'passing assert is green')
+  assert.ok(
+    stdout.includes(BOLD_GREEN + 'ok' + RESET + ' 1 - passing' + DIM + ' # time = '),
+    'a passing test is bold green with a dimmed timing'
+  )
+
+  assert.ok(
+    stdout.includes(
+      BOLD_YELLOW +
+        'ok' +
+        RESET +
+        YELLOW +
+        ' 2 - skipping' +
+        RESET +
+        BOLD_YELLOW +
+        ' # SKIP' +
+        RESET
+    ),
+    'a skipped test is yellow with a bold marker'
+  )
+  assert.ok(
+    stdout.includes(
+      BOLD_YELLOW + 'ok' + RESET + YELLOW + ' 3 - todoing' + RESET + BOLD_YELLOW + ' # TODO' + RESET
+    ),
+    'a todo test is yellow with a bold marker'
+  )
+
+  assert.ok(
+    stdout.includes(BOLD_RED + 'not ok' + RESET + RED + ' 1 - nope' + RESET),
+    'a failing assert is red with a bold status'
+  )
+  assert.ok(stdout.includes(DIM + '      ---' + RESET), 'the explanation delimiters are dimmed')
+  assert.ok(stdout.includes(BOLD_RED + 'not ok' + RESET + RED + ' 4 - failing' + RESET))
+
+  assert.ok(stdout.includes(DIM + '1..4' + RESET), 'the plan line is dimmed')
+  assert.ok(stdout.includes(BOLD_RED + '# tests = 3/4 pass' + RESET), 'a failing tally is bold red')
+  assert.ok(
+    stdout.includes(BOLD_RED + '# asserts = 1/2 pass' + RESET),
+    'a failing tally is bold red'
+  )
+  assert.ok(stdout.includes(DIM + '# time = '), 'the total time is dimmed')
+  assert.ok(stdout.includes(BOLD_RED + '# not ok' + RESET), 'the final verdict is bold red')
+}
+
+// the explanation reads like a diff: expected green, actual red, pointer highlighted
+
+{
+  const { stdout } = await raw(
+    function (test) {
+      test('failing', (t) => {
+        t.plan(1)
+        t.is(1, 2, 'one is two')
+      })
+    },
+    { env: { ...NEUTRAL, FORCE_COLOR: '1' } }
+  )
+
+  assert.ok(
+    stdout.includes(BOLD_RED + '      actual:' + RESET + ' ' + RED + '1' + RESET),
+    'actual is red'
+  )
+  assert.ok(
+    stdout.includes(BOLD_GREEN + '      expected:' + RESET + ' ' + GREEN + '2' + RESET),
+    'expected is green'
+  )
+  assert.ok(
+    stdout.includes(BOLD + '      operator:' + RESET + ' ' + GRAY + 'is' + RESET),
+    'other keys are bold with gray values'
+  )
+  assert.ok(/\x1b\[1m\x1b\[31m\s*-*\^\x1b\[0m/.test(stdout), 'the source pointer is bold red')
+  assert.ok(/\x1b\[90m\s+t\.is\(1, 2, 'one is two'\)\x1b\[0m/.test(stdout), 'source lines are gray')
+  assert.ok(
+    /\x1b\[1m {6}stack:\x1b\[0m \x1b\[90m\|\x1b\[0m\n\x1b\[2m\s+\S/.test(stdout),
+    'stack frames are dimmed'
+  )
+}
+
+// an all-passing run gets green tallies and a green verdict
+
+{
+  const { stdout } = await raw(
+    function (test) {
+      test('passing', (t) => t.pass())
+    },
+    { env: { ...NEUTRAL, FORCE_COLOR: '1' } }
+  )
+
+  assert.ok(stdout.includes(GREEN + '# tests = 1/1 pass' + RESET), 'passing tally is green')
+  assert.ok(stdout.includes(GREEN + '# asserts = 1/1 pass' + RESET), 'passing tally is green')
+  assert.ok(stdout.includes(BOLD_GREEN + '# ok' + RESET), 'the final verdict is bold green')
+}
+
+// configure({ color }) overrides detection in both directions
+
+{
+  const { stdout } = await raw(
+    function ({ test, configure }) {
+      configure({ color: false })
+      test('plain', (t) => t.pass())
+    },
+    { env: { ...NEUTRAL, FORCE_COLOR: '1' } }
+  )
+
+  assert.ok(!stdout.includes('\x1b['), 'configure({ color: false }) disables colors')
+}
+
+{
+  const { stdout } = await raw(
+    function ({ test, configure }) {
+      configure({ color: true })
+      test('colored', (t) => t.pass())
+    },
+    { env: NEUTRAL }
+  )
+
+  assert.ok(
+    stdout.includes(BOLD_GREEN + '# ok' + RESET),
+    'configure({ color: true }) enables colors'
+  )
+}
+
+// the bail out line is red
+
+{
+  const { stdout } = await raw(
+    function ({ test, configure }) {
+      configure({ bail: true, color: true })
+      test('failing', (t) => {
+        t.plan(1)
+        t.fail()
+      })
+    },
+    { env: NEUTRAL }
+  )
+
+  assert.ok(stdout.includes(BOLD_RED + 'Bail out!' + RESET), 'Bail out! is bold red')
+}
+
+// --color and --no-color override detection from the CLI
+
+{
+  const cmd = path.join(__dirname, '..', 'cmd.js')
+  const fixture = 'test/fixtures/colors/passing.js' // relative: the glob rejects absolute paths
+
+  const forced = await run([cmd, '--color', fixture], NEUTRAL)
+  assert.strictEqual(forced.exitCode, 0)
+  assert.ok(forced.stdout.includes(BOLD_GREEN + '# ok' + RESET), '--color forces colors on a pipe')
+
+  const disabled = await run([cmd, '--no-color', fixture], { ...NEUTRAL, FORCE_COLOR: '1' })
+  assert.strictEqual(disabled.exitCode, 0)
+  assert.ok(!disabled.stdout.includes('\x1b['), '--no-color forces colors off')
+
+  const auto = await run([cmd, fixture], NEUTRAL)
+  assert.strictEqual(auto.exitCode, 0)
+  assert.ok(!auto.stdout.includes('\x1b['), 'no flag means auto-detect')
+}
+
+// the mixed fixture exercises every colorized line kind at once
+
+{
+  const cmd = path.join(__dirname, '..', 'cmd.js')
+  const fixture = 'test/fixtures/colors/mixed.js'
+
+  const { stdout, exitCode } = await run([cmd, '--color', fixture], NEUTRAL)
+
+  assert.notStrictEqual(exitCode, 0, 'the fixture has a failing test')
+  assert.ok(stdout.includes(GREEN + 'ok' + RESET + ' 1 - a passing assertion'), 'pass is green')
+  assert.ok(stdout.includes(BOLD_GREEN + 'ok' + RESET + ' 1 - passing' + DIM), 'test line is bold')
+  assert.ok(stdout.includes(BOLD_YELLOW + ' # SKIP' + RESET), 'the skip marker is bold yellow')
+  assert.ok(stdout.includes(BOLD_YELLOW + ' # TODO' + RESET), 'the todo marker is bold yellow')
+  assert.ok(stdout.includes(DIM + '    # a nested comment' + RESET), 'nested comment is dim')
+  assert.ok(
+    stdout.includes('    ' + GREEN + 'ok' + RESET + ' 1 - (child) - a nested assertion'),
+    'nested pass is green'
+  )
+  assert.ok(
+    stdout.includes(BOLD_RED + 'not ok' + RESET + RED + ' 1 - one is two' + RESET),
+    'failing assert is red'
+  )
+  assert.ok(stdout.includes(DIM + '      ---' + RESET), 'the explanation delimiter is dim')
+  assert.ok(stdout.includes(BOLD_RED + '# not ok' + RESET), 'the verdict is bold red')
+}
+
+function run(args, env) {
+  return new Promise((resolve, reject) => {
+    const opts = { cwd: path.join(__dirname, '..') }
+    if (env) opts.env = { ...process.env, ...env }
+
+    const child = spawn(process.execPath, args, opts)
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.setEncoding('utf-8')
+    child.stderr.setEncoding('utf-8')
+    child.stdout.on('data', (data) => {
+      stdout += data
+    })
+    child.stderr.on('data', (data) => {
+      stderr += data
+    })
+
+    child.on('error', reject)
+    child.on('exit', (exitCode) => resolve({ exitCode, stdout, stderr }))
+  })
 }

--- a/test/color.mjs
+++ b/test/color.mjs
@@ -168,6 +168,8 @@ const NEUTRAL = { NO_COLOR: '', FORCE_COLOR: '', TERM: 'xterm-256color' }
     'a failing tally is bold red'
   )
   assert.ok(stdout.includes(DIM + '# time = '), 'the total time is dimmed')
+  assert.ok(stdout.includes(BOLD_RED + '# failures:' + RESET), 'the failures roll-up is bold red')
+  assert.ok(stdout.includes(RED + '#   - failing' + RESET), 'each failed test name is listed')
   assert.ok(stdout.includes(BOLD_RED + '# not ok' + RESET), 'the final verdict is bold red')
 }
 
@@ -202,6 +204,36 @@ const NEUTRAL = { NO_COLOR: '', FORCE_COLOR: '', TERM: 'xterm-256color' }
     /\x1b\[1m {6}stack:\x1b\[0m \x1b\[90m\|\x1b\[0m\n\x1b\[2m\s+\S/.test(stdout),
     'stack frames are dimmed'
   )
+}
+
+// the failures roll-up lists every failed test, and is absent when all pass
+
+{
+  const failing = await raw(
+    function (test) {
+      test('first', (t) => t.pass())
+      test('second', (t) => {
+        t.plan(1)
+        t.fail()
+      })
+      test('third', (t) => {
+        t.plan(1)
+        t.fail()
+      })
+    },
+    { env: NEUTRAL }
+  )
+
+  assert.ok(failing.stdout.includes('# failures:\n#   - second\n#   - third'), 'both are listed')
+
+  const passing = await raw(
+    function (test) {
+      test('first', (t) => t.pass())
+    },
+    { env: NEUTRAL }
+  )
+
+  assert.ok(!passing.stdout.includes('# failures:'), 'no roll-up when everything passes')
 }
 
 // an all-passing run gets green tallies and a green verdict
@@ -307,6 +339,8 @@ const NEUTRAL = { NO_COLOR: '', FORCE_COLOR: '', TERM: 'xterm-256color' }
     'failing assert is red'
   )
   assert.ok(stdout.includes(DIM + '      ---' + RESET), 'the explanation delimiter is dim')
+  assert.ok(stdout.includes(BOLD_RED + '# failures:' + RESET), 'the failures roll-up is shown')
+  assert.ok(stdout.includes(RED + '#   - failing' + RESET), 'the failed test is named')
   assert.ok(stdout.includes(BOLD_RED + '# not ok' + RESET), 'the verdict is bold red')
 }
 

--- a/test/fixtures/colors/mixed.js
+++ b/test/fixtures/colors/mixed.js
@@ -1,0 +1,30 @@
+const test = require('../../../')
+
+test('passing', (t) => {
+  t.plan(2)
+  t.pass('a passing assertion')
+  t.is(1, 1, 'one is one')
+})
+
+test('skipped', { skip: true }, (t) => {
+  t.pass()
+})
+
+test('todo', { todo: true }, (t) => {
+  t.pass()
+})
+
+test('nested', (t) => {
+  t.plan(1)
+  t.test('child', (child) => {
+    child.plan(1)
+    child.comment('a nested comment')
+    child.pass('a nested assertion')
+  })
+})
+
+test('failing', (t) => {
+  t.plan(1)
+  t.comment('about to fail')
+  t.is(1, 2, 'one is two')
+})

--- a/test/fixtures/colors/passing.js
+++ b/test/fixtures/colors/passing.js
@@ -1,0 +1,6 @@
+const test = require('../../../')
+
+test('colorized', (t) => {
+  t.plan(1)
+  t.pass('colorized assertion')
+})

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -12,7 +12,7 @@ const ERROR_EXIT_CODE = isBare ? (isWindows ? 3221226505 : 134) : 1
 const EXIT_CODES_KV = { ok: 0, error: ERROR_EXIT_CODE }
 const EXIT_CODES_VK = { 0: 'ok', [ERROR_EXIT_CODE]: 'error' }
 
-module.exports = { tester, spawner, standardizeTap, ERROR_EXIT_CODE }
+module.exports = { tester, spawner, raw, standardizeTap, ERROR_EXIT_CODE }
 
 async function tester(name, fn, expectedOut, expectedMore, opts) {
   log('Tester', name)
@@ -28,22 +28,25 @@ async function spawner(fn, expectedOut, expectedMore, opts) {
   return executeTap(script, expectedOut, expectedMore, opts)
 }
 
-async function executeTap(
-  script,
-  expectedOut,
-  more = {},
-  opts = {
-    scriptFile: path.resolve(
-      __dirname,
-      '..',
-      `_testscript-${Math.random().toString(16).slice(2)}.js`
-    )
-  }
-) {
+async function raw(fn, opts = {}) {
+  log('Raw')
+  const script = `const test = require(${pkg})\n\nconst _fn = (${fn.toString()})\n\n_fn(test)`
+  const scriptFile =
+    opts.scriptFile ??
+    path.resolve(__dirname, '..', `_testscript-${Math.random().toString(16).slice(2)}.js`)
+
+  return executeCode(script, scriptFile, opts)
+}
+
+async function executeTap(script, expectedOut, more = {}, opts = {}) {
   if (typeof expectedOut !== 'string') throw new Error('Expected stdout is required as a string')
   if (more.stderr === undefined) throw new Error('Expected stderr is required')
 
-  const { exitCode, error, stdout, stderr } = await executeCode(script, opts.scriptFile)
+  const scriptFile =
+    opts.scriptFile ??
+    path.resolve(__dirname, '..', `_testscript-${Math.random().toString(16).slice(2)}.js`)
+
+  const { exitCode, error, stdout, stderr } = await executeCode(script, scriptFile, opts)
   const errors = new Errors()
   let tapout
   let tapexp
@@ -168,12 +171,13 @@ class Errors {
   }
 }
 
-function executeCode(script, scriptFile = null) {
+function executeCode(script, scriptFile = null, { env } = {}) {
   return new Promise((resolve, reject) => {
     if (scriptFile) fs.writeFileSync(scriptFile, script, 'utf-8')
 
     const args = scriptFile ? [scriptFile] : ['-e', script]
     const opts = { timeout: 30000, cwd: path.join(__dirname, '../..') }
+    if (env) opts.env = { ...process.env, ...env }
     const child = spawn(process.execPath, args, opts)
 
     let stdout = ''


### PR DESCRIPTION
Stack 3/3 — sits on #119 (color helper lib) and #120 (colorize TAP output).

Since GitHub cannot base a PR on a fork branch, this targets `main` and the diff includes the two
PRs below it until they merge; the slice specific to this PR is the top commit
(`feat(output): add a failures roll-up to the summary`).

Lists every failed top-level test in a roll-up before the final verdict, so a long run does not
have to be scrolled to find what broke:

```
# tests = 4/5 pass
# asserts = 3/4 pass
# time = 15ms

# failures:
#   - failing

# not ok
```

The roll-up is emitted as TAP comments, so it is present with or without colors and is ignored by
TAP consumers. With colors on, the header is bold red and each entry red.