### PR TITLE
feat(cli): add --watch with an interactive watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Flags:
   --timeout, -t <timeout>   Set the test timeout in milliseconds (default: 30000)
   --mine, -m <miners>       Keep running the tests in <miners> processes until they fail.
   --jobs, -j <jobs>         Run <jobs> test files concurrently [Bare-only] (default: 1)
+  --watch, -w               Rerun the tests when a test file changes
   --unstealth, -u           Show assertions even if stealth is used
   --help|-h                 Show help
 ```
@@ -850,6 +851,55 @@ Force disable coverage with an environment variable:
 ```shell
 BRITTLE_COVERAGE=false brittle-node test.js
 ```
+
+### Watch mode
+
+`--watch` keeps the process alive, watching the test files that were matched and rerunning
+them when one changes.
+
+```sh
+brittle-node --watch test/*.mjs
+brittle-bare -w -b test/all.mjs
+```
+
+Each file runs in its own process, so a pass or fail is attributed per file, and a summary is
+printed at the end of every run:
+
+```
+ PASS  test/pass.mjs 61ms
+ FAIL  test/nesting.mjs 128ms
+
+Files:   1 failed, 1 passed, 2 total
+Tests:   1 failed, 42 passed, 43 total
+Asserts: 1 failed, 98 passed, 99 total
+Time:    0.19s
+
+Failed files:
+  - test/nesting.mjs
+```
+
+When stdin is a terminal, watch mode is interactive:
+
+```
+Watch Usage
+ › Press a to run all tests.
+ › Press f to run only failed files.
+ › Press o to run only changed files.
+ › Press p to filter by a filename regex.
+ › Press q to quit watch mode.
+ › Press enter to trigger a test run.
+```
+
+`f` and `o` narrow the run to the files that failed, or changed, since the last run. `p`
+prompts for a regex that is matched against the file paths — an empty pattern clears it, and
+`a` clears every filter. When stdin is not a terminal (CI, a pipe) the keys are skipped and
+watch mode just reruns on change.
+
+Only the matched test files are watched, not the code under test, so editing an
+implementation file does not trigger a rerun on its own — press enter, or save the test.
+
+The other flags are forwarded to each run, so `--bail`, `--timeout`, `--solo`, `--pick`,
+`--coverage` and `--jobs` all behave as usual. `--watch` cannot be combined with `--mine`.
 
 ### Coverage
 

--- a/cmd.js
+++ b/cmd.js
@@ -27,6 +27,7 @@ const cmd = command(
   flag('--mine, -m <miners>', 'Keep running the tests in <miners> processes until they fail.'),
   flag('--unstealth, -u', 'Print out assertions even if stealth is used'),
   flag('--jobs, -j <jobs>', 'Run <jobs> test files concurrently [Bare-only] (default: 1)'),
+  flag('--watch, -w', 'Rerun the tests when a test file changes'),
   rest('<files>')
 ).parse(args)
 if (!cmd) process.exit(0)
@@ -46,7 +47,7 @@ if (files.length === 0) {
   process.exit(1)
 }
 
-const { solo, bail, timeout, coverage, covDir, mine, trace, unstealth, jobs } = argv
+const { solo, bail, timeout, coverage, covDir, mine, trace, unstealth, jobs, watch } = argv
 
 if (argv.pick && argv.pick.length > 1) {
   console.error('Error: --pick can only be used once')
@@ -65,6 +66,11 @@ if (jobs && Number(jobs) > 1 && pick !== undefined) {
   process.exit(1)
 }
 
+if (watch && mine) {
+  console.error('Error: --watch and --mine cannot be used together')
+  process.exit(1)
+}
+
 process.title = 'brittle'
 
 if (trace && !mine) {
@@ -78,9 +84,13 @@ if (trace && !mine) {
   })
 }
 
-if (coverage && process.env.BRITTLE_COVERAGE !== 'false') require('bare-cov')({ dir: covDir })
+// in watch mode coverage belongs to the spawned runs, not to the watcher itself
+if (coverage && !watch && process.env.BRITTLE_COVERAGE !== 'false') {
+  require('bare-cov')({ dir: covDir })
+}
 
-if (mine) startMining().catch()
+if (watch) startWatching()
+else if (mine) startMining().catch()
 else start().catch(onerror)
 
 function onerror(err) {
@@ -113,6 +123,30 @@ async function start() {
   }
 
   brittle.resume()
+}
+
+function startWatching() {
+  const { watch: run } = require('./lib/watch')
+
+  run({
+    cmd: __filename,
+    files,
+    args: forwardedFlags(),
+    color: process.stdout?.isTTY === true && !process.env.NO_COLOR
+  })
+}
+
+function forwardedFlags() {
+  return []
+    .concat(solo ? ['--solo'] : [])
+    .concat(bail ? ['--bail'] : [])
+    .concat(unstealth ? ['--unstealth'] : [])
+    .concat(trace ? ['--trace'] : [])
+    .concat(coverage ? ['--coverage'] : [])
+    .concat(covDir ? ['--cov-dir', covDir] : [])
+    .concat(timeout ? ['--timeout', timeout + ''] : [])
+    .concat(jobs ? ['--jobs', jobs] : [])
+    .concat(pick !== undefined ? ['--pick', pick + ''] : [])
 }
 
 async function startMining() {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,0 +1,466 @@
+const fs = require('fs')
+const path = require('path')
+const process = require('process')
+const { spawn } = require('child_process')
+const ansi = require('bare-ansi-escapes')
+
+const DEBOUNCE = 200
+const REARM = 50
+
+const TALLY = /^# (tests|asserts) = (\d+)\/(\d+) pass$/
+
+exports.watch = watch
+
+// exported for tests
+exports.decodeKeys = decodeKeys
+exports.selectFiles = selectFiles
+exports.summaryLine = summaryLine
+exports.parseTally = parseTally
+exports.toPattern = toPattern
+exports.nothingToRun = nothingToRun
+
+function watch({ cmd, files, args, color }) {
+  const style = createStyle(color)
+  const interactive = process.stdin?.isTTY === true
+
+  const state = {
+    mode: 'all',
+    pattern: null,
+    failed: new Set(),
+    changed: new Set(),
+    prompt: null
+  }
+
+  const watchers = []
+  const seen = new Map()
+  let debounce = null
+  let current = null
+  let token = 0
+  let closed = false
+
+  for (const file of files) arm(file)
+
+  if (interactive) {
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+    process.stdin.on('data', onstdin)
+  } else {
+    process.on('SIGINT', quit)
+  }
+
+  run('initial run')
+
+  function arm(file) {
+    let watcher
+
+    // record the current mtime up front: the platform can deliver a stale event
+    // for a write that happened before the watcher existed
+    unchanged(file)
+
+    try {
+      watcher = fs.watch(file, (type) => {
+        // an atomic save replaces the inode, so the old handle is now watching
+        // a file that no longer exists
+        if (type === 'rename') {
+          watcher.close()
+          setTimeout(() => {
+            if (!closed) arm(file)
+          }, REARM)
+        }
+
+        // a single save can surface as several events (truncate then write), so
+        // ignore any that did not move the mtime
+        if (unchanged(file)) return
+
+        state.changed.add(file)
+        trigger(path.relative(process.cwd(), file) + ' changed')
+      })
+    } catch {
+      write(style.yellow('! cannot watch ' + file))
+      return
+    }
+
+    watchers.push(watcher)
+  }
+
+  function unchanged(file) {
+    let mtime
+
+    try {
+      mtime = fs.statSync(file).mtimeMs
+    } catch {
+      return false // mid-save, let the run decide
+    }
+
+    if (seen.get(file) === mtime) return true
+
+    seen.set(file, mtime)
+    return false
+  }
+
+  function trigger(reason) {
+    if (closed) return
+    clearTimeout(debounce)
+    debounce = setTimeout(() => run(reason), DEBOUNCE)
+  }
+
+  async function run(reason) {
+    const mine = ++token
+
+    if (current) {
+      current.kill()
+      current = null
+    }
+
+    const selected = selectFiles(state, files)
+
+    clear()
+    write(style.dim('brittle watch — ' + reason))
+    write('')
+
+    if (selected.length === 0) {
+      write(style.yellow(nothingToRun(state)))
+      write('')
+      usage()
+      return
+    }
+
+    const started = Date.now()
+    const failed = []
+    const tests = { pass: 0, count: 0 }
+    const asserts = { pass: 0, count: 0 }
+
+    for (const file of selected) {
+      if (mine !== token) return
+
+      const relative = path.relative(process.cwd(), file)
+      write(style.dim('── ' + relative + ' ' + '─'.repeat(Math.max(0, 60 - relative.length))))
+
+      const result = await runFile(file, tests, asserts)
+
+      if (mine !== token) return
+
+      if (result.ok) {
+        write(style.badgePass(' PASS ') + ' ' + relative + style.dim(' ' + result.duration + 'ms'))
+      } else {
+        failed.push(file)
+        write(style.badgeFail(' FAIL ') + ' ' + relative + style.dim(' ' + result.duration + 'ms'))
+      }
+
+      write('')
+    }
+
+    state.failed = new Set(failed)
+    state.changed.clear()
+
+    summary({ selected, failed, tests, asserts, duration: Date.now() - started })
+    usage()
+  }
+
+  function runFile(file, tests, asserts) {
+    return new Promise((resolve) => {
+      const started = Date.now()
+      const child = spawn(process.execPath, [cmd, ...args, file], {
+        cwd: process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+
+      current = child
+
+      lines(child.stdout, (line) => {
+        const tally = parseTally(line)
+
+        if (tally) {
+          const target = tally.kind === 'tests' ? tests : asserts
+          target.pass += tally.pass
+          target.count += tally.count
+        }
+
+        write(line)
+      })
+
+      lines(child.stderr, (line) => write(style.red(line)))
+
+      child.on('error', (error) => {
+        write(style.red(error.message))
+      })
+
+      child.on('close', (code, signal) => {
+        if (current === child) current = null
+        resolve({ ok: code === 0 && !signal, duration: Date.now() - started })
+      })
+    })
+  }
+
+  function summary({ selected, failed, tests, asserts, duration }) {
+    const files = {
+      failed: failed.length,
+      passed: selected.length - failed.length,
+      total: selected.length
+    }
+
+    write(style.count('Files', files))
+    write(style.count('Tests', counts(tests)))
+    write(style.count('Asserts', counts(asserts)))
+    write(style.dim('Time:    ' + (duration / 1000).toFixed(2) + 's'))
+
+    if (failed.length > 0) {
+      write('')
+      write(style.boldRed('Failed files:'))
+      for (const file of failed) {
+        write(style.red('  - ' + path.relative(process.cwd(), file)))
+      }
+    }
+
+    write('')
+  }
+
+  function usage() {
+    if (!interactive) {
+      write(style.dim('Watching ' + files.length + ' file(s) for changes — ctrl-c to exit.'))
+      return
+    }
+
+    if (state.prompt !== null) {
+      write(style.bold('Filter by filename regex') + style.dim(' (enter to apply, esc to cancel)'))
+      write(' › ' + state.prompt)
+      return
+    }
+
+    const active = []
+    if (state.mode === 'failed') active.push('failed only')
+    if (state.mode === 'changed') active.push('changed only')
+    if (state.pattern) active.push('/' + state.pattern.source + '/')
+
+    write(style.bold('Watch Usage'))
+    write(style.dim(' › Press ') + 'a' + style.dim(' to run all tests.'))
+    write(style.dim(' › Press ') + 'f' + style.dim(' to run only failed files.'))
+    write(style.dim(' › Press ') + 'o' + style.dim(' to run only changed files.'))
+    write(style.dim(' › Press ') + 'p' + style.dim(' to filter by a filename regex.'))
+    write(style.dim(' › Press ') + 'q' + style.dim(' to quit watch mode.'))
+    write(style.dim(' › Press ') + 'enter' + style.dim(' to trigger a test run.'))
+
+    if (active.length > 0) write(style.dim(' › Active filters: ') + active.join(', '))
+  }
+
+  function onstdin(chunk) {
+    for (const key of decodeKeys(chunk)) {
+      if (state.prompt !== null) {
+        onprompt(key)
+        continue
+      }
+
+      if (key.ctrl && key.name === 'c') return quit()
+
+      switch (key.name) {
+        case 'q':
+          return quit()
+        case 'a':
+          state.mode = 'all'
+          state.pattern = null
+          return run('running all tests')
+        case 'f':
+          state.mode = 'failed'
+          return run('running failed files')
+        case 'o':
+          state.mode = 'changed'
+          return run('running changed files')
+        case 'p':
+          state.prompt = ''
+          clear()
+          usage()
+          continue
+        case 'return':
+          return run('manual run')
+        default:
+          continue
+      }
+    }
+  }
+
+  function onprompt(key) {
+    if (key.ctrl && key.name === 'c') return quit()
+
+    if (key.name === 'escape') {
+      state.prompt = null
+      clear()
+      usage()
+      return
+    }
+
+    if (key.name === 'return') {
+      const pattern = toPattern(state.prompt)
+      state.prompt = null
+
+      if (pattern === null) {
+        clear()
+        write(style.red('Not a valid regex.'))
+        write('')
+        usage()
+        return
+      }
+
+      state.pattern = pattern
+      state.mode = 'all'
+      run(pattern ? 'filtering by /' + pattern.source + '/' : 'filter cleared')
+      return
+    }
+
+    if (key.name === 'backspace') {
+      state.prompt = state.prompt.slice(0, -1)
+    } else if (key.name.length === 1 && !key.ctrl) {
+      state.prompt += key.name
+    }
+
+    clear()
+    usage()
+  }
+
+  function quit() {
+    if (closed) return
+    closed = true
+
+    clearTimeout(debounce)
+    for (const watcher of watchers) watcher.close()
+    if (current) current.kill()
+
+    if (interactive) {
+      process.stdin.off('data', onstdin)
+      process.stdin.setRawMode(false)
+      process.stdin.pause()
+    }
+
+    write('')
+  }
+
+  function clear() {
+    if (interactive) process.stdout.write(ansi.eraseDisplay + ansi.cursorPosition(0, 0))
+  }
+}
+
+function nothingToRun({ mode, pattern }) {
+  if (mode === 'failed') return 'No failed files. Press a to run all tests.'
+  if (mode === 'changed') return 'No files have changed yet. Press a to run all tests.'
+  if (pattern) return 'No test files match /' + pattern.source + '/. Press a to clear the filter.'
+  return 'No test files to run.'
+}
+
+function counts({ pass, count }) {
+  return { failed: count - pass, passed: pass, total: count }
+}
+
+function summaryLine(label, { failed, passed, total }) {
+  const parts = []
+  if (failed > 0) parts.push(failed + ' failed')
+  parts.push(passed + ' passed')
+  parts.push(total + ' total')
+
+  return (label + ':').padEnd(8) + ' ' + parts.join(', ')
+}
+
+function parseTally(line) {
+  const match = TALLY.exec(line.trim())
+  if (match === null) return null
+
+  return { kind: match[1], pass: Number(match[2]), count: Number(match[3]) }
+}
+
+// '' clears the filter, an invalid regex returns null
+function toPattern(input) {
+  if (input === '') return false
+
+  try {
+    return new RegExp(input)
+  } catch {
+    return null
+  }
+}
+
+function decodeKeys(chunk) {
+  const data = chunk.toString()
+  const keys = []
+
+  for (let i = 0; i < data.length; i++) {
+    const c = data[i]
+
+    if (c === '\x1b') {
+      // consume an escape sequence so that arrow keys are not read as letters
+      if (data[i + 1] === '[' || data[i + 1] === 'O') {
+        i += 2
+        while (i < data.length && !/[A-Za-z~]/.test(data[i])) i++
+        keys.push({ name: 'unknown', ctrl: false })
+      } else {
+        keys.push({ name: 'escape', ctrl: false })
+      }
+      continue
+    }
+
+    if (c === '\r' || c === '\n') keys.push({ name: 'return', ctrl: false })
+    else if (c === '\x7f' || c === '\b') keys.push({ name: 'backspace', ctrl: false })
+    else if (c < ' ') keys.push({ name: String.fromCharCode(c.charCodeAt(0) + 96), ctrl: true })
+    else keys.push({ name: c, ctrl: false })
+  }
+
+  return keys
+}
+
+function selectFiles({ mode, pattern, failed, changed }, files) {
+  let selected = files
+
+  if (mode === 'failed') selected = selected.filter((file) => failed.has(file))
+  else if (mode === 'changed') selected = selected.filter((file) => changed.has(file))
+
+  if (pattern) selected = selected.filter((file) => pattern.test(file))
+
+  return selected
+}
+
+function lines(stream, onLine) {
+  let buffer = ''
+
+  stream.setEncoding('utf-8')
+  stream.on('data', (chunk) => {
+    buffer += chunk
+
+    while (true) {
+      const at = buffer.indexOf('\n')
+      if (at === -1) break
+      onLine(buffer.slice(0, at))
+      buffer = buffer.slice(at + 1)
+    }
+  })
+
+  stream.on('end', () => {
+    if (buffer !== '') onLine(buffer)
+  })
+}
+
+function write(line) {
+  console.log(line)
+}
+
+function createStyle(color) {
+  const paint = (open) => (string) => (color ? open + string + ansi.modifierReset : string)
+
+  const dim = paint(ansi.modifierDim)
+  const bold = paint(ansi.modifierBold)
+  const red = paint(ansi.colorRed)
+  const green = paint(ansi.colorGreen)
+  const yellow = paint(ansi.colorYellow)
+  const boldRed = paint(ansi.modifierBold + ansi.colorRed)
+
+  return {
+    dim,
+    bold,
+    red,
+    green,
+    yellow,
+    boldRed,
+    badgePass: paint(ansi.modifierBold + ansi.colorBlack + ansi.constants.SGR(42)),
+    badgeFail: paint(ansi.modifierBold + ansi.colorWhite + ansi.constants.SGR(41)),
+    count(label, values) {
+      const line = summaryLine(label, values)
+      return values.failed > 0 ? boldRed(line) : green(line)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "b4a": "^1.8.0",
+    "bare-ansi-escapes": "^2.2.3",
     "bare-assert": "^1.2.0",
     "bare-buffer": "^3.6.0",
     "bare-channel": "^5.2.3",

--- a/test/fixtures/watch/failing.js
+++ b/test/fixtures/watch/failing.js
@@ -1,0 +1,7 @@
+const test = require('../../../')
+
+// flip this to t.pass('beta is fixed') and save while `--watch` is running
+test('beta', (t) => {
+  t.plan(1)
+  t.fail('beta is broken')
+})

--- a/test/fixtures/watch/passing.js
+++ b/test/fixtures/watch/passing.js
@@ -1,0 +1,7 @@
+const test = require('../../../')
+
+test('alpha', (t) => {
+  t.plan(2)
+  t.pass('a passing assertion')
+  t.is(1, 1, 'one is one')
+})

--- a/test/watch.mjs
+++ b/test/watch.mjs
@@ -1,0 +1,207 @@
+import assert from 'assert'
+import fs from 'fs'
+import path from 'path'
+import process from 'process'
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'url'
+import {
+  decodeKeys,
+  selectFiles,
+  summaryLine,
+  parseTally,
+  toPattern,
+  nothingToRun
+} from '../lib/watch.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.join(__dirname, '..')
+
+// bare-assert has no deepStrictEqual or match, so compare shapes as JSON and
+// regexes explicitly
+function same(actual, expected, message) {
+  assert.strictEqual(JSON.stringify(actual), JSON.stringify(expected), message)
+}
+
+function matches(text, regex, message) {
+  assert.ok(regex.test(text), (message ?? 'expected ' + regex) + '\n---\n' + text + '\n---')
+}
+
+// decodeKeys turns raw terminal bytes into named keys
+
+{
+  same(decodeKeys('a'), [{ name: 'a', ctrl: false }])
+  same(decodeKeys('\r'), [{ name: 'return', ctrl: false }])
+  same(decodeKeys('\n'), [{ name: 'return', ctrl: false }])
+  same(decodeKeys('\x7f'), [{ name: 'backspace', ctrl: false }])
+  same(decodeKeys('\x03'), [{ name: 'c', ctrl: true }])
+  same(decodeKeys('\x1b'), [{ name: 'escape', ctrl: false }])
+
+  // a whole paste is decoded in order
+  same(decodeKeys('ab\r'), [
+    { name: 'a', ctrl: false },
+    { name: 'b', ctrl: false },
+    { name: 'return', ctrl: false }
+  ])
+
+  // arrow keys are swallowed rather than read as the letters in their sequence
+  same(decodeKeys('\x1b[A'), [{ name: 'unknown', ctrl: false }])
+  same(decodeKeys('\x1bOB'), [{ name: 'unknown', ctrl: false }])
+  same(decodeKeys('\x1b[Aq'), [
+    { name: 'unknown', ctrl: false },
+    { name: 'q', ctrl: false }
+  ])
+}
+
+// selectFiles applies the mode and the pattern
+
+{
+  const files = ['test/a.js', 'test/b.js', 'test/c.js']
+  const base = { failed: new Set(['test/b.js']), changed: new Set(['test/c.js']) }
+
+  same(selectFiles({ ...base, mode: 'all', pattern: null }, files), files)
+  same(selectFiles({ ...base, mode: 'failed', pattern: null }, files), ['test/b.js'])
+  same(selectFiles({ ...base, mode: 'changed', pattern: null }, files), ['test/c.js'])
+  same(selectFiles({ ...base, mode: 'all', pattern: /[ac]\.js/ }, files), [
+    'test/a.js',
+    'test/c.js'
+  ])
+
+  // mode and pattern compose
+  same(selectFiles({ ...base, mode: 'failed', pattern: /a\.js/ }, files), [])
+
+  // a cleared pattern is not applied
+  same(selectFiles({ ...base, mode: 'all', pattern: false }, files), files)
+}
+
+// toPattern
+
+{
+  assert.strictEqual(toPattern(''), false, 'empty input clears the filter')
+  assert.ok(toPattern('nest') instanceof RegExp)
+  assert.strictEqual(toPattern('nest').source, 'nest')
+  assert.strictEqual(toPattern('a['), null, 'an invalid regex is rejected')
+}
+
+// parseTally reads the runner's own summary comments
+
+{
+  same(parseTally('# tests = 4/5 pass'), { kind: 'tests', pass: 4, count: 5 })
+  same(parseTally('# asserts = 0/1 pass'), { kind: 'asserts', pass: 0, count: 1 })
+  assert.strictEqual(parseTally('# time = 5ms'), null)
+  assert.strictEqual(parseTally('ok 1 - passing'), null)
+  assert.strictEqual(parseTally('# tests = 4/5'), null)
+}
+
+// summaryLine only mentions failures when there are some
+
+{
+  assert.strictEqual(
+    summaryLine('Files', { failed: 0, passed: 2, total: 2 }),
+    'Files:   2 passed, 2 total'
+  )
+  assert.strictEqual(
+    summaryLine('Asserts', { failed: 1, passed: 3, total: 4 }),
+    'Asserts: 1 failed, 3 passed, 4 total'
+  )
+}
+
+// nothingToRun explains why the selection is empty
+
+{
+  matches(nothingToRun({ mode: 'failed', pattern: null }), /No failed files/)
+  matches(nothingToRun({ mode: 'changed', pattern: null }), /have changed/)
+  matches(nothingToRun({ mode: 'all', pattern: /nope/ }), /match \/nope\//)
+  matches(nothingToRun({ mode: 'all', pattern: null }), /No test files to run/)
+}
+
+// end to end: the watcher runs everything, reports per file, then reruns on a change
+
+{
+  const dir = path.join(__dirname, `_watch-${Math.random().toString(16).slice(2)}`)
+  const relative = path.relative(root, dir)
+  const passing = path.join(dir, 'passing.js')
+  const failing = path.join(dir, 'failing.js')
+
+  fs.mkdirSync(dir)
+
+  try {
+    write(passing, "test('alpha', (t) => { t.plan(1); t.pass('a ok') })")
+    write(failing, "test('beta', (t) => { t.plan(1); t.fail('b broken') })")
+
+    const run = start([`${relative}/*.js`])
+
+    try {
+      await run.waitFor('Watching')
+
+      matches(run.output(), / PASS {2}\S*passing\.js/, 'the passing file is reported')
+      matches(run.output(), / FAIL {2}\S*failing\.js/, 'the failing file is reported')
+      matches(run.output(), /Files: {3}1 failed, 1 passed, 2 total/)
+      matches(run.output(), /Tests: {3}1 failed, 1 passed, 2 total/)
+      matches(run.output(), /Asserts: 1 failed, 1 passed, 2 total/)
+      matches(run.output(), /Failed files:\n\s+- \S*failing\.js/)
+      assert.ok(!run.output().includes('\x1b['), 'a piped watcher does not colorize')
+
+      run.clear()
+      write(failing, "test('beta', (t) => { t.plan(1); t.pass('fixed') })")
+
+      await run.waitFor('Watching')
+
+      matches(run.output(), /brittle watch — \S*failing\.js changed/, 'the change is reported')
+      matches(run.output(), /Files: {3}2 passed, 2 total/, 'the rerun passes')
+      assert.ok(!run.output().includes('FAIL'), 'nothing fails after the fix')
+      assert.ok(!run.output().includes('Failed files:'), 'the failed list is gone')
+    } finally {
+      run.kill()
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function write(file, body) {
+  fs.writeFileSync(file, `const test = require(${JSON.stringify(root)})\n\n${body}\n`, 'utf-8')
+}
+
+function start(args) {
+  const child = spawn(process.execPath, [path.join(root, 'cmd.js'), '--watch', ...args], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+
+  let buffer = ''
+  let stderr = ''
+
+  child.stdout.setEncoding('utf-8')
+  child.stderr.setEncoding('utf-8')
+  child.stdout.on('data', (data) => {
+    buffer += data
+  })
+  child.stderr.on('data', (data) => {
+    stderr += data
+  })
+
+  return {
+    output: () => buffer,
+    clear: () => {
+      buffer = ''
+    },
+    kill: () => child.kill(),
+    async waitFor(marker, timeout = 30000) {
+      const deadline = Date.now() + timeout
+
+      while (Date.now() < deadline) {
+        if (buffer.includes(marker)) return
+        await sleep(50)
+      }
+
+      throw new Error(
+        `timed out waiting for ${JSON.stringify(marker)}\n[stdout]\n${buffer}\n[stderr]\n${stderr}`
+      )
+    }
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
Adds `--watch, -w`: keeps the process alive, watches the test files that were matched, and reruns them when one changes. Interactive when stdin is a terminal, jest-style.

```sh
brittle-node --watch test/*.mjs
brittle-bare -w -b test/all.mjs
```

## Behaviour

Each file runs in its own process, so a pass or fail is attributed per file:

```
 PASS  test/pass.mjs 61ms
 FAIL  test/nesting.mjs 128ms

Files:   1 failed, 1 passed, 2 total
Tests:   1 failed, 42 passed, 43 total
Asserts: 1 failed, 98 passed, 99 total
Time:    0.19s

Failed files:
  - test/nesting.mjs
```

When stdin is a TTY:

```
Watch Usage
 › Press a to run all tests.
 › Press f to run only failed files.
 › Press o to run only changed files.
 › Press p to filter by a filename regex.
 › Press q to quit watch mode.
 › Press enter to trigger a test run.
```


https://github.com/user-attachments/assets/137e9166-1bf0-4909-88ad-26aa3c3b451c



`f` and `o` narrow the run to the files that failed, or changed, since the last run. `p` prompts for a regex matched against the file paths — an empty pattern clears it, `a` clears every filter. When stdin is not a TTY (CI, a pipe) the keys are skipped and watch mode just reruns on change.

Only the matched test files are watched, not the code under test, so editing an implementation file does not trigger a rerun on its own — press enter, or save the test.

Other flags are forwarded to each run, so `--bail`, `--timeout`, `--solo`, `--pick`, `--coverage` and `--jobs` behave as usual. `--watch` cannot be combined with `--mine`. In watch mode coverage is enabled in the spawned runs rather than in the watcher process.

## Implementation notes

- The runner is single-shot per process (global runner, `beforeExit` deadlock detection), so watch mode spawns a child per run instead of rerunning in-process — the same approach `--mine` already takes. `cmd.js` gains the flag and hands off to a new `lib/watch.js`; nothing in `index.js` changes.
- One child **per test file**, run sequentially. That is what makes `f` possible: an exit code per file gives real per-file attribution, which a single all-files child cannot provide. Aggregate tallies come from parsing the runner's own `# tests = a/b pass` and `# asserts = a/b pass` comments, and each child's output is streamed through as it arrives rather than buffered.
- Keys are decoded by a small local parser rather than `bare-ansi-escapes/key-decoder`, because that module imports `bare-stream`, which is not usable under Node. Only single-byte keys are needed. Arrow-key escape sequences are consumed so that `\x1b[A` is not read as `A`.
- File events are deduplicated by mtime, and the mtime map is primed when each watcher is armed. Without this, macOS delivers stale and duplicate events — same mtime and size, observed up to ~2s late — and a write that happened *before* the watcher existed triggers a phantom run against pre-change content. Events are also debounced (200ms), and a `rename` (atomic save) re-arms the watcher since the inode is replaced.
- `fs.watch` and raw-mode stdin both come from the existing import map, so the same code path runs on Node and Bare with no runtime branches.

## Tests

`test/watch.mjs` unit-tests the pure logic — `decodeKeys` (including ctrl-c, backspace, pastes, arrow-key sequences), `selectFiles` (mode and pattern, and how they compose), `toPattern`, `parseTally`, `summaryLine`, `nothingToRun` — then runs the watcher end to end over two generated fixtures: asserts the per-file badges, the three tally lines, the failed-file list and that a piped watcher emits no escapes; then rewrites the failing file and asserts the change is reported, the rerun passes, and the failed list is gone.

`test/fixtures/watch/` holds `passing.js` and `failing.js` for driving watch mode by hand:

```sh
node cmd.js --watch 'test/fixtures/watch/*.js'
```

Flip the `t.fail` in `failing.js` to a `t.pass` and save to watch it go green.

Full suite passes on Node and Bare; `prettier --check` and `lunte` are clean.

## Note on overlap with #117

This branch is independent of #117 (colored output), as requested, but both add `bare-ansi-escapes` to `package.json` — that one line will conflict for whichever merges second. `lib/watch.js` also carries its own small `createStyle` helper rather than reusing `lib/colors.js` from #117; worth unifying in a follow-up once one of them lands.
