### PR TITLE
feat: add ANSI color helper lib

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,72 @@
+const ansi = require('bare-ansi-escapes')
+const process = require('process')
+
+const { modifierReset, modifierBold, modifierDim } = ansi
+
+const STYLES = {
+  green: ansi.colorGreen,
+  red: ansi.colorRed,
+  yellow: ansi.colorYellow,
+  gray: ansi.colorBrightBlack,
+  bold: modifierBold,
+  dim: modifierDim,
+  boldGreen: modifierBold + ansi.colorGreen,
+  boldRed: modifierBold + ansi.colorRed,
+  boldYellow: modifierBold + ansi.colorYellow
+}
+
+const NAMES = Object.keys(STYLES)
+
+function identity(string) {
+  return string
+}
+
+function env(name) {
+  try {
+    return process.env?.[name]
+  } /* c8 ignore next */ catch {
+    /* c8 ignore next */
+    return undefined
+  }
+}
+
+function isColorSupported() {
+  const noColor = env('NO_COLOR')
+  if (noColor) return false
+
+  const forceColor = env('FORCE_COLOR')
+  if (forceColor !== undefined && forceColor !== '') {
+    return forceColor !== '0' && forceColor !== 'false'
+  }
+
+  if (env('TERM') === 'dumb') return false
+
+  try {
+    return process.stdout?.isTTY === true
+  } /* c8 ignore next */ catch {
+    /* c8 ignore next */
+    return false
+  }
+}
+
+function paint(open) {
+  return function (string) {
+    string = string + ''
+    if (string === '') return string
+    // per line so that resets survive wrapping and indentation
+    return string
+      .split('\n')
+      .map((line) => (line === '' ? line : open + line + modifierReset))
+      .join('\n')
+  }
+}
+
+function createColors(enabled = isColorSupported()) {
+  const colors = { enabled: !!enabled }
+  for (const name of NAMES) {
+    colors[name] = enabled ? paint(STYLES[name]) : identity
+  }
+  return colors
+}
+
+module.exports = { createColors, isColorSupported }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "b4a": "^1.8.0",
+    "bare-ansi-escapes": "^2.2.3",
     "bare-assert": "^1.2.0",
     "bare-buffer": "^3.6.0",
     "bare-channel": "^5.2.3",

--- a/test/color.mjs
+++ b/test/color.mjs
@@ -1,0 +1,65 @@
+import assert from 'assert'
+import { createColors, isColorSupported } from '../lib/colors.js'
+
+const GREEN = '\x1b[32m'
+const RED = '\x1b[31m'
+const YELLOW = '\x1b[33m'
+const GRAY = '\x1b[90m'
+const BOLD = '\x1b[1m'
+const DIM = '\x1b[2m'
+const RESET = '\x1b[0m'
+const BOLD_GREEN = BOLD + GREEN
+const BOLD_RED = BOLD + RED
+const BOLD_YELLOW = BOLD + YELLOW
+
+// createColors(false) leaves every string untouched
+
+{
+  const colors = createColors(false)
+  assert.strictEqual(colors.enabled, false)
+  const names = ['green', 'red', 'yellow', 'gray', 'bold', 'dim', 'boldGreen', 'boldRed']
+  for (const name of names) {
+    assert.strictEqual(colors[name]('ok 1 - passed'), 'ok 1 - passed')
+  }
+}
+
+// createColors(true) wraps in the matching SGR sequence
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.enabled, true)
+  assert.strictEqual(colors.green('ok'), GREEN + 'ok' + RESET)
+  assert.strictEqual(colors.red('not ok'), RED + 'not ok' + RESET)
+  assert.strictEqual(colors.yellow('SKIP'), YELLOW + 'SKIP' + RESET)
+  assert.strictEqual(colors.gray('---'), GRAY + '---' + RESET)
+  assert.strictEqual(colors.bold('# test'), BOLD + '# test' + RESET)
+  assert.strictEqual(colors.dim('# time = 0ms'), DIM + '# time = 0ms' + RESET)
+  assert.strictEqual(colors.boldGreen('# ok'), BOLD_GREEN + '# ok' + RESET)
+  assert.strictEqual(colors.boldRed('# not ok'), BOLD_RED + '# not ok' + RESET)
+  assert.strictEqual(colors.boldYellow('# SKIP'), BOLD_YELLOW + '# SKIP' + RESET)
+}
+
+// empty strings and blank lines are never wrapped, other lines are wrapped individually
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.green(''), '')
+  assert.strictEqual(
+    colors.gray('---\n\nactual: 1'),
+    GRAY + '---' + RESET + '\n\n' + GRAY + 'actual: 1' + RESET
+  )
+}
+
+// non-strings are coerced
+
+{
+  const colors = createColors(true)
+  assert.strictEqual(colors.green(1), GREEN + '1' + RESET)
+}
+
+// detection defaults to whatever the current stdout is
+
+{
+  assert.strictEqual(typeof isColorSupported(), 'boolean')
+  assert.strictEqual(createColors().enabled, isColorSupported())
+}


### PR DESCRIPTION
Stack 1/3 — reviewable slices of #117: this PR → colorize TAP output → failures roll-up (#117).

Adds `lib/colors.js`: a small ANSI styling helper built on `bare-ansi-escapes`.

- `createColors(enabled?)` returns per-style painters (green, red, yellow, gray, bold, dim and bold
  variants); when disabled every painter is the identity function
- auto-detection honors `NO_COLOR`, `FORCE_COLOR`, `TERM=dumb` and stdout TTY
- multi-line strings are wrapped per line so resets survive wrapping and indentation
- unit tests in `test/color.mjs`

No behavior change — nothing uses the lib until the next PR in the stack.